### PR TITLE
2017098048 empregado

### DIFF
--- a/Empregado.hpp
+++ b/Empregado.hpp
@@ -8,19 +8,16 @@ class Empregado {
 	
   public:
     double salarioHora;  
-    double quotaMensalVendas;  
-
 
     double pagamentoMes(double horasTrabalhadas) {
- 
-      double t = horasTrabalhadas;
+      double horasMes = horasTrabalhadas;
 	  
 	  //Cálculo de hora extra (+50% se horasTrabalhadas > 8)
       if (horasTrabalhadas > 8) {
-        double x = horasTrabalhadas - 8;
-        t += x / 2;
+        double extra = horasTrabalhadas - 8;
+        horasMes += extra / 2;
       }
-	  return t * salarioHora;
+	  return horasMes * salarioHora;
     }
 	
 };


### PR DESCRIPTION
1)Retirei o quotaMensalVendas, uma vez que esta informação pertence somente à subclasse vendedor;
2) Alterei o nome das variaveis x e t para deixar mais didático